### PR TITLE
fix(routes): mount all routers under /api prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ app.use(
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
-app.use(router);
+app.use('/api', router);
 app.use(errorsHandler);
 app.all("*", error404);
 


### PR DESCRIPTION
Front-end expects endpoints at /api/hadiths, /api/dhikrs, etc. Previously mounted at root, causing 404 for every API call. /health stays at root for infra health checks.