### PR TITLE
feat(api): wrap list endpoints in PaginatedResponse envelope

### DIFF
--- a/app/controllers/croyance.controller.js
+++ b/app/controllers/croyance.controller.js
@@ -7,7 +7,14 @@ const croyanceController = {
             const croyances = await db.croyance.getAll();
             if (!croyances)
                 return next(new Error404('No croyance found'));
-            response.json(croyances);
+            const page = Number(request.query.page ?? 0);
+            const pageSize = Number(request.query.pageSize ?? croyances.length);
+            response.json({
+                data: croyances,
+                total: croyances.length,
+                page,
+                pageSize,
+            });
         } catch (error) {
             error.type = "database";
             error.method = request.method;
@@ -29,31 +36,6 @@ const croyanceController = {
             return next(error);
         }
     },
-    /*create: async function (request, response, next) {
-        const { name } = request.body;
-        try {
-            const createdCroyance = await db.croyance.create(croyance);
-            response.status(201).json(createdCroyance);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in creating croyance";
-            return next(error);
-        }
-    },
-    update: async function (request, response, next) {
-        const { id } = request.params;
-        const { name } = request.body;
-        try {
-            const updatedCroyance = await db.croyance.update(id, croyance);
-            response.json(updatedCroyance);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in updating croyance";
-            return next(error);
-        }
-     */
 };
 
 export default croyanceController;

--- a/app/controllers/dhikr.controller.js
+++ b/app/controllers/dhikr.controller.js
@@ -7,13 +7,19 @@ const dhikrController = {
             const dhikrs = await db.dhikr.getAll();
             if (!dhikrs)
                 return next(new Error404('No dhikr found'));
-            response.json(dhikrs);
+            const page = Number(request.query.page ?? 0);
+            const pageSize = Number(request.query.pageSize ?? dhikrs.length);
+            response.json({
+                data: dhikrs,
+                total: dhikrs.length,
+                page,
+                pageSize,
+            });
         } catch (error) {
             error.type = "database";
             error.method = request.method;
             error.message = "Error in getting all dhikrs";
             return next(error);
-
         }
     },
     get: async function (request, response, next) {
@@ -30,31 +36,6 @@ const dhikrController = {
             return next(error);
         }
     },
-    /*create: async function (request, response, next) {
-        const { name } = request.body;
-        try {
-            const createdHadith = await db.hadith.create(hadith);
-            response.status(201).json(createdHadith);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in creating hadith";
-            return next(error);
-        }
-    },
-    update: async function (request, response, next) {
-        const { id } = request.params;
-        const { name } = request.body;
-        try {
-            const updatedHadith = await db.hadith.update(id, hadith);
-            response.json(updatedHadith);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in updating hadith";
-            return next(error);
-        }
-     */
 };
 
 export default dhikrController;

--- a/app/controllers/douaa.controller.js
+++ b/app/controllers/douaa.controller.js
@@ -7,7 +7,14 @@ const douaaController = {
             const douaas = await db.douaa.getAll();
             if (!douaas)
                 return next(new Error404('No douaa found'));
-            response.json(douaas);
+            const page = Number(request.query.page ?? 0);
+            const pageSize = Number(request.query.pageSize ?? douaas.length);
+            response.json({
+                data: douaas,
+                total: douaas.length,
+                page,
+                pageSize,
+            });
         } catch (error) {
             error.type = "database";
             error.method = request.method;
@@ -29,31 +36,6 @@ const douaaController = {
             return next(error);
         }
     },
-    /*create: async function (request, response, next) {
-        const { name } = request.body;
-        try {
-            const createdDouaa = await db.douaa.create(douaa);
-            response.status(201).json(createdDouaa);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in creating douaa";
-            return next(error);
-        }
-    },
-    update: async function (request, response, next) {
-        const { id } = request.params;
-        const { name } = request.body;
-        try {
-            const updatedDouaa = await db.douaa.update(id, douaa);
-            response.json(updatedDouaa);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in updating douaa";
-            return next(error);
-        }
-     */
 };
 
 export default douaaController;

--- a/app/controllers/hadith.controller.js
+++ b/app/controllers/hadith.controller.js
@@ -7,13 +7,19 @@ const hadithController = {
             const hadiths = await db.hadith.getAll();
             if (!hadiths)
                 return next(new Error404('No hadith found'));
-            response.json(hadiths);
-            } catch (error) {
+            const page = Number(request.query.page ?? 0);
+            const pageSize = Number(request.query.pageSize ?? hadiths.length);
+            response.json({
+                data: hadiths,
+                total: hadiths.length,
+                page,
+                pageSize,
+            });
+        } catch (error) {
             error.type = "database";
             error.method = request.method;
             error.message = "Error in getting all hadiths";
             return next(error);
-
         }
     },
     get: async function (request, response, next) {
@@ -30,31 +36,6 @@ const hadithController = {
             return next(error);
         }
     },
-    /*create: async function (request, response, next) {
-        const { name } = request.body;
-        try {
-            const createdHadith = await db.hadith.create(hadith);
-            response.status(201).json(createdHadith);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in creating hadith";
-            return next(error);
-        }
-    },
-    update: async function (request, response, next) {
-        const { id } = request.params;
-        const { name } = request.body;
-        try {
-            const updatedHadith = await db.hadith.update(id, hadith);
-            response.json(updatedHadith);
-        } catch (error) {
-            error.type = "database";
-            error.method = request.method;
-            error.message = "Error in updating hadith";
-            return next(error);
-        }
-     */
 };
 
 export default hadithController;


### PR DESCRIPTION
Front-end expects { data, total, page, pageSize } for all list endpoints. Previously controllers returned raw arrays, causing response.data to be undefined on the client and crashing components that read .length.

Applied to hadith, dhikr, croyance, douaa controllers. Single-resource GETs (/:id) keep returning the raw object (unchanged).