### PR TITLE
fix(schema): aligner le back sur le vrai schema PostgreSQL

### DIFF
--- a/app/controllers/coran.controller.js
+++ b/app/controllers/coran.controller.js
@@ -1,0 +1,49 @@
+import db from '../models/index.datamapper.js';
+import { Error404 } from '../utils/errors/index.utils.js';
+
+const coranController = {
+  getAll: async function (request, response, next) {
+    try {
+      const versets = await db.coran.getAll();
+      if (!versets) return next(new Error404('No verset found'));
+      const page     = Number(request.query.page     ?? 0);
+      const pageSize = Number(request.query.pageSize ?? versets.length);
+      response.json({ data: versets, total: versets.length, page, pageSize });
+    } catch (error) {
+      error.type = 'database'; error.method = request.method;
+      error.message = 'Error in getting all versets';
+      return next(error);
+    }
+  },
+
+  get: async function (request, response, next) {
+    const { id } = request.params;
+    try {
+      const verset = await db.coran.get(id);
+      if (!verset) return next(new Error404('Verset not found'));
+      response.json(verset);
+    } catch (error) {
+      error.type = 'database'; error.method = request.method;
+      error.message = 'Error in getting verset';
+      return next(error);
+    }
+  },
+
+  create: async function (request, response, next) {
+    try {
+      const row = await db.coran.create(request.body);
+      if (!row)
+        return response.status(409).json({ message: 'Ce verset existe déjà dans la base de données.' });
+      response.status(201).json(row);
+    } catch (error) { next(error); }
+  },
+
+  createBulk: async function (request, response, next) {
+    try {
+      const summary = await db.coran.createBulk(request.body.items);
+      response.json(summary);
+    } catch (error) { next(error); }
+  },
+};
+
+export default coranController;

--- a/app/controllers/index.controller.js
+++ b/app/controllers/index.controller.js
@@ -1,9 +1,13 @@
-import hadithController from './hadith.controller.js';
-import croyanceController from "./croyance.controller.js";
-import dhikrController from "./dhikr.controller.js";
-import douaaController from "./douaa.controller.js";
-
+import hadithController  from './hadith.controller.js';
+import dhikrController   from './dhikr.controller.js';
+import douaaController   from './douaa.controller.js';
+import coranController   from './coran.controller.js';
+import paroleController  from './parole.controller.js';
 
 export {
-    hadithController, croyanceController, dhikrController, douaaController
+  hadithController,
+  dhikrController,
+  douaaController,
+  coranController,
+  paroleController,
 };

--- a/app/controllers/parole.controller.js
+++ b/app/controllers/parole.controller.js
@@ -1,0 +1,50 @@
+import db from '../models/index.datamapper.js';
+import { Error404 } from '../utils/errors/index.utils.js';
+
+// Contrôleur pour la table `parole` (citations de savants, route /savants)
+const paroleController = {
+  getAll: async function (request, response, next) {
+    try {
+      const paroles = await db.parole.getAll();
+      if (!paroles) return next(new Error404('No citation found'));
+      const page     = Number(request.query.page     ?? 0);
+      const pageSize = Number(request.query.pageSize ?? paroles.length);
+      response.json({ data: paroles, total: paroles.length, page, pageSize });
+    } catch (error) {
+      error.type = 'database'; error.method = request.method;
+      error.message = 'Error in getting all citations';
+      return next(error);
+    }
+  },
+
+  get: async function (request, response, next) {
+    const { id } = request.params;
+    try {
+      const parole = await db.parole.get(id);
+      if (!parole) return next(new Error404('Citation not found'));
+      response.json(parole);
+    } catch (error) {
+      error.type = 'database'; error.method = request.method;
+      error.message = 'Error in getting citation';
+      return next(error);
+    }
+  },
+
+  create: async function (request, response, next) {
+    try {
+      const row = await db.parole.create(request.body);
+      if (!row)
+        return response.status(409).json({ message: 'Cette citation existe déjà dans la base de données.' });
+      response.status(201).json(row);
+    } catch (error) { next(error); }
+  },
+
+  createBulk: async function (request, response, next) {
+    try {
+      const summary = await db.parole.createBulk(request.body.items);
+      response.json(summary);
+    } catch (error) { next(error); }
+  },
+};
+
+export default paroleController;

--- a/app/models/coran.datamapper.js
+++ b/app/models/coran.datamapper.js
@@ -1,0 +1,52 @@
+import { client } from '../services/index.service.js';
+import { hashArabic } from '../utils/arabic.utils.js';
+
+const coranDatamapper = {
+  get: async function (id) {
+    const result = await client.query('SELECT * FROM coran WHERE id = $1', [id]);
+    return result.rows[0];
+  },
+
+  getAll: async function () {
+    const result = await client.query('SELECT * FROM coran');
+    return result.rows;
+  },
+
+  create: async function (data) {
+    const hash = hashArabic(data.texte_arabe);
+    const sql = `
+      INSERT INTO coran
+        (sujet, sourate, texte_arabe, texte_francais, "phonétique", explication, tag, arabe_hash)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+      ON CONFLICT (arabe_hash) DO NOTHING
+      RETURNING *
+    `;
+    const result = await client.query(sql, [
+      data.sujet,
+      data.sourate        ?? null,
+      data.texte_arabe,
+      data.texte_francais ?? null,
+      data['phonétique']  ?? null,
+      data.explication    ?? null,
+      data.tag            ?? '',
+      hash,
+    ]);
+    return result.rows[0];
+  },
+
+  createBulk: async function (items) {
+    const summary = { inserted: 0, duplicates: 0, errors: [] };
+    for (const item of items) {
+      try {
+        const row = await this.create(item);
+        if (row) summary.inserted++;
+        else     summary.duplicates++;
+      } catch (err) {
+        summary.errors.push({ sujet: item.sujet, error: err.message });
+      }
+    }
+    return summary;
+  },
+};
+
+export default coranDatamapper;

--- a/app/models/index.datamapper.js
+++ b/app/models/index.datamapper.js
@@ -1,16 +1,18 @@
-import hadithDatamapper from "./hadith.datamapper.js";
-import croyanceDatamapper from "./croyance.datamapper.js";
-import dhikrDatamapper from "./dhikr.datamapper.js";
-import douaaDatamapper from "./douaa.datamapper.js";
+import hadithDatamapper  from './hadith.datamapper.js';
+import dhikrDatamapper   from './dhikr.datamapper.js';
+import douaaDatamapper   from './douaa.datamapper.js';
+import coranDatamapper   from './coran.datamapper.js';
+import paroleDatamapper  from './parole.datamapper.js';
 
+// Note : la table `croyance` n'existe pas encore en BDD.
+// Le datamapper croyance est retiré jusqu'à création de la table.
 
 const db = {
-    hadith: hadithDatamapper,
-    croyance: croyanceDatamapper,
-    dhikr: dhikrDatamapper,
-    douaa: douaaDatamapper,
+  hadith:  hadithDatamapper,
+  dhikr:   dhikrDatamapper,
+  douaa:   douaaDatamapper,
+  coran:   coranDatamapper,
+  parole:  paroleDatamapper,
 };
-
-
 
 export default db;

--- a/app/models/parole.datamapper.js
+++ b/app/models/parole.datamapper.js
@@ -1,0 +1,53 @@
+import { client } from '../services/index.service.js';
+import { hashArabic } from '../utils/arabic.utils.js';
+
+// Table `parole` = citations de savants (appelée "Savants" côté front)
+const paroleDatamapper = {
+  get: async function (id) {
+    const result = await client.query('SELECT * FROM parole WHERE id = $1', [id]);
+    return result.rows[0];
+  },
+
+  getAll: async function () {
+    const result = await client.query('SELECT * FROM parole');
+    return result.rows;
+  },
+
+  create: async function (data) {
+    const hash = hashArabic(data.texte_arabe);
+    const sql = `
+      INSERT INTO parole
+        (sujet, savant, texte_arabe, texte_francais, "phonétique", explication, tag, arabe_hash)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+      ON CONFLICT (arabe_hash) DO NOTHING
+      RETURNING *
+    `;
+    const result = await client.query(sql, [
+      data.sujet,
+      data.savant         ?? '',
+      data.texte_arabe,
+      data.texte_francais ?? null,
+      data['phonétique']  ?? null,
+      data.explication    ?? null,
+      data.tag            ?? '',
+      hash,
+    ]);
+    return result.rows[0];
+  },
+
+  createBulk: async function (items) {
+    const summary = { inserted: 0, duplicates: 0, errors: [] };
+    for (const item of items) {
+      try {
+        const row = await this.create(item);
+        if (row) summary.inserted++;
+        else     summary.duplicates++;
+      } catch (err) {
+        summary.errors.push({ sujet: item.sujet, error: err.message });
+      }
+    }
+    return summary;
+  },
+};
+
+export default paroleDatamapper;

--- a/app/routes/coran.router.js
+++ b/app/routes/coran.router.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import { z } from 'zod';
+import { coranController as coran } from '../controllers/index.controller.js';
+import { validateId, validateQuery, validateBody } from '../middlewares/index.middleware.js';
+
+const router = express.Router();
+
+const coranSchema = z.object({
+  sujet:          z.string().trim().min(1).max(500),
+  sourate:        z.string().trim().max(200).optional().nullable(),
+  texte_arabe:    z.string().trim().min(1),
+  texte_francais: z.string().trim().max(5000).optional().nullable(),
+  'phonétique':   z.string().trim().max(2000).optional().nullable(),
+  explication:    z.string().trim().max(10000).optional().nullable(),
+  tag:            z.string().trim().max(500).default(''),
+});
+
+router.get('/coran',       validateQuery,                                                   coran.getAll);
+router.get('/coran/:id',   validateId,                                                     coran.get);
+router.post('/coran',      validateBody(coranSchema),                                      coran.create);
+router.post('/coran/bulk', validateBody(z.object({ items: coranSchema.array().min(1).max(500) })), coran.createBulk);
+
+export default router;

--- a/app/routes/index.router.js
+++ b/app/routes/index.router.js
@@ -1,16 +1,19 @@
-import hadithRouter  from "./hadith.router.js";
-import croyanceRouter from "./croyance.router.js";
-import dhikrRouter from "./dhikr.router.js";
-import douaaRouter from "./douaa.router.js";
-import express from "express";
+import express from 'express';
+import hadithRouter  from './hadith.router.js';
+import dhikrRouter   from './dhikr.router.js';
+import douaaRouter   from './douaa.router.js';
+import coranRouter   from './coran.router.js';
+import paroleRouter  from './parole.router.js';
+
+// Note : croyanceRouter retiré — la table `croyance` n'existe pas encore.
+// À réintégrer quand la table sera créée en BDD.
 
 const router = express.Router();
 
 router.use(hadithRouter);
-router.use(croyanceRouter);
 router.use(dhikrRouter);
 router.use(douaaRouter);
-
-
+router.use(coranRouter);
+router.use(paroleRouter);
 
 export default router;

--- a/app/routes/parole.router.js
+++ b/app/routes/parole.router.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import { z } from 'zod';
+import { paroleController as parole } from '../controllers/index.controller.js';
+import { validateId, validateQuery, validateBody } from '../middlewares/index.middleware.js';
+
+const router = express.Router();
+
+// La table DB s'appelle `parole` mais le front appelle /savants
+const paroleSchema = z.object({
+  sujet:          z.string().trim().min(1).max(500),
+  savant:         z.string().trim().min(1).max(300),
+  texte_arabe:    z.string().trim().min(1),
+  texte_francais: z.string().trim().max(5000).optional().nullable(),
+  'phonétique':   z.string().trim().max(2000).optional().nullable(),
+  explication:    z.string().trim().max(10000).optional().nullable(),
+  tag:            z.string().trim().max(500).default(''),
+});
+
+router.get('/savants',        validateQuery,                                                    parole.getAll);
+router.get('/savant/:id',     validateId,                                                       parole.get);
+router.post('/savants',       validateBody(paroleSchema),                                       parole.create);
+router.post('/savants/bulk',  validateBody(z.object({ items: paroleSchema.array().min(1).max(500) })), parole.createBulk);
+
+export default router;

--- a/scripts/migrate-add-hashes.js
+++ b/scripts/migrate-add-hashes.js
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 /**
- * Script de migration one-shot — à exécuter UNE SEULE FOIS :
+ * Run once to add deduplication to existing tables:
  *   node scripts/migrate-add-hashes.js
- *
- * Effectue dans une transaction :
- *  1. Ajoute la colonne arabe_hash sur hadith, dhikr, douaa, croyance
- *  2. Calcule les hashs pour les lignes existantes (normalisation JS)
- *  3. Supprime les doublons (garde l'id le plus bas)
- *  4. Rend la colonne NOT NULL et ajoute la contrainte UNIQUE
  */
 import 'dotenv/config';
 import pg from 'pg';
@@ -16,33 +10,28 @@ import { hashArabic } from '../app/utils/arabic.utils.js';
 const client = new pg.Client();
 await client.connect();
 
-const TABLES = ['hadith', 'dhikr', 'douaa', 'croyance'];
+// Tables qui ont une colonne texte_arabe
+const TABLES = ['hadith', 'dhikr', 'douaa', 'coran', 'parole'];
 
 try {
   await client.query('BEGIN');
 
-  // 1. Ajouter la colonne (nullable)
   for (const table of TABLES) {
     await client.query(`ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS arabe_hash TEXT`);
     console.log(`✓ ${table}: colonne arabe_hash ajoutée`);
   }
 
-  // 2. Calculer et remplir les hashs
   for (const table of TABLES) {
     const { rows } = await client.query(
       `SELECT id, texte_arabe FROM ${table} WHERE arabe_hash IS NULL`
     );
     for (const row of rows) {
       const hash = hashArabic(row.texte_arabe);
-      await client.query(
-        `UPDATE ${table} SET arabe_hash = $1 WHERE id = $2`,
-        [hash, row.id]
-      );
+      await client.query(`UPDATE ${table} SET arabe_hash = $1 WHERE id = $2`, [hash, row.id]);
     }
     console.log(`✓ ${table}: ${rows.length} hash(es) calculé(s)`);
   }
 
-  // 3. Supprimer les doublons (garde le plus ancien id)
   for (const table of TABLES) {
     const { rowCount } = await client.query(`
       DELETE FROM ${table} a
@@ -50,21 +39,14 @@ try {
       WHERE  a.arabe_hash = b.arabe_hash
         AND  a.id > b.id
     `);
-    const msg = rowCount > 0
-      ? `⚠️  ${rowCount} doublon(s) supprimé(s)`
-      : `✓ aucun doublon`;
-    console.log(`  ${table}: ${msg}`);
+    console.log(`  ${table}: ${rowCount > 0 ? `⚠️  ${rowCount} doublon(s) supprimé(s)` : '✓ aucun doublon'}`);
   }
 
-  // 4. NOT NULL + contrainte UNIQUE
   for (const table of TABLES) {
-    await client.query(
-      `ALTER TABLE ${table} ALTER COLUMN arabe_hash SET NOT NULL`
-    );
+    await client.query(`ALTER TABLE ${table} ALTER COLUMN arabe_hash SET NOT NULL`);
     await client.query(`
       DO $$ BEGIN
-        ALTER TABLE ${table}
-          ADD CONSTRAINT uq_${table}_arabe_hash UNIQUE (arabe_hash);
+        ALTER TABLE ${table} ADD CONSTRAINT uq_${table}_arabe_hash UNIQUE (arabe_hash);
       EXCEPTION WHEN duplicate_table THEN NULL;
       END $$;
     `);


### PR DESCRIPTION
- scripts/migrate-add-hashes.js: remplace croyance (inexistante) par coran et parole dans la liste des tables à migrer
- Ajout coran.datamapper/controller/router (table `coran` existante)
- Ajout parole.datamapper/controller/router (table `parole` = savants front) → route GET/POST /savants, /savant/:id
- index.datamapper + index.controller : retrait de croyance, ajout coran/parole
- index.router : retrait croyanceRouter, ajout coranRouter + paroleRouter
- Note : croyanceRouter mis de côté jusqu'à création de la table en BDD