### PR TITLE
Corrige l'erreur duplicate key parole_pkey : resynchronisation des sé…

### DIFF
--- a/scripts/005_seed_islamms_hadith_douaa_dhikr.sql
+++ b/scripts/005_seed_islamms_hadith_douaa_dhikr.sql
@@ -14,6 +14,12 @@
 -- Colonne tag (filtrage) si absente :
 ALTER TABLE hadith ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise les séquences d'id (précaution : si des lignes existantes ont
+-- des id posés explicitement, la séquence peut être en retard → erreur pkey).
+SELECT setval(pg_get_serial_sequence('hadith', 'id'), COALESCE((SELECT MAX(id) FROM hadith), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('douaa', 'id'), COALESCE((SELECT MAX(id) FROM douaa), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('dhikr', 'id'), COALESCE((SELECT MAX(id) FROM dhikr), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islam.ms/causes-bien-invocations-aumones

--- a/scripts/006_seed_islamsunnite_paroles_part1of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part1of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/chaykh-al-marighni-attributs-de-allah/

--- a/scripts/006_seed_islamsunnite_paroles_part2of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part2of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/ahmad-zarrouq-explique-istiwa-allah-trone/

--- a/scripts/006_seed_islamsunnite_paroles_part3of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part3of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/mouhammad-illaych-al-maliki-eloge-mawlid/

--- a/scripts/006_seed_islamsunnite_paroles_part4of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part4of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/imam-souyouti-confirme-bonne-innovation-bida/

--- a/scripts/006_seed_islamsunnite_paroles_part5of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part5of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/limam-al-bayhaqi-parle-du-yad-du-wajh-du-ayn-du-nouzoul-de-allah/

--- a/scripts/006_seed_islamsunnite_paroles_part6of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part6of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/limam-al-mawsili-confirme-que-les-moujassimah-sont-mecreants/

--- a/scripts/006_seed_islamsunnite_paroles_part7of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part7of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/limam-abou-hayyan-al-andalouci-confirme-que-allah-nest-pas-dans-une-direction/

--- a/scripts/006_seed_islamsunnite_paroles_part8of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part8of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/limam-an-nawawi-explique-le-hadith-al-jariyah-hadith-de-la-femme-esclave/

--- a/scripts/006_seed_islamsunnite_paroles_part9of9.sql
+++ b/scripts/006_seed_islamsunnite_paroles_part9of9.sql
@@ -15,6 +15,11 @@
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS savant VARCHAR(255) DEFAULT '';
 ALTER TABLE parole ADD COLUMN IF NOT EXISTS tag VARCHAR(255) DEFAULT '';
 
+-- Resynchronise la séquence des id : des lignes existantes ont des id posés
+-- explicitement et la séquence était en retard, d'où l'erreur
+-- « duplicate key value violates unique constraint "parole_pkey" ».
+SELECT setval(pg_get_serial_sequence('parole', 'id'), COALESCE((SELECT MAX(id) FROM parole), 0) + 1, false);
+
 BEGIN;
 
 -- source: https://islamsunnite.net/limam-al-qourtoubi-explique-le-verset-de-listawa/


### PR DESCRIPTION
…quences

Les tables contiennent des lignes dont les id ont été posés explicitement, mais la séquence d'auto-incrément était restée en arrière : chaque INSERT demandait un id déjà pris → « duplicate key value violates unique constraint parole_pkey ». Ajout d'un setval(pg_get_serial_sequence(...), MAX(id)+1) en tête des 9 parties du seeding 006 (et du 005 par précaution pour hadith/douaa/dhikr).

Reproduit et vérifié sur PostgreSQL 16 local : table pré-remplie avec des id explicites et séquence en retard → les 9 parties passent, lignes existantes intactes, ré-exécution idempotente.


Claude-Session: https://claude.ai/code/session_016LyoBDUqT81dSZtuTiqNgs